### PR TITLE
Get away from master and slave vocabulary

### DIFF
--- a/db.py
+++ b/db.py
@@ -8,7 +8,7 @@
 '''
 import sys
 import MySQLdb
-#from slave import Connection
+#from subordinate import Connection
 from MySQLdb.cursors import DictCursor
 import datetime
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.